### PR TITLE
Create conf.ROOT_DIR if it doesn't exist

### DIFF
--- a/static_sitemaps/management/commands/refresh_sitemap.py
+++ b/static_sitemaps/management/commands/refresh_sitemap.py
@@ -61,8 +61,8 @@ class Command(NoArgsCommand):
                     'lastmod': lastmod
                 })
 
-        if not os.path.isdir(conf.ROOT_DIR, 0755):
-            os.makedirs(conf.ROOT_DIR)
+        if not os.path.isdir(conf.ROOT_DIR):
+            os.makedirs(conf.ROOT_DIR, 0755)
         f = open(os.path.join(conf.ROOT_DIR, 'sitemap.xml'), 'w')
         f.write(smart_str(loader.render_to_string(conf.INDEX_TEMPLATE,
                                                   {'sitemaps': parts})))


### PR DESCRIPTION
This should fix #6.

I'm not sure whether `os.makedirs` is a good idea (might create bad empty folder trees if there's a typo in `ROOT_DIR`). The alternative would be `os.mkdir` and to raise an exception if the nonexisting folder tree is too deep.
