### PR TITLE
replace domain setting with extended url settings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,7 @@ Done.
 prepended the domain to respect the current ``Site`` object. If your
 ``STATIC_URL`` is absolute (generally doesn't start with a '/'), sitemaps
 URL will respect it completely. If you need more detailed control, see
-``STATICSITEMAPS_DOMAIN`` setting.
+``STATICSITEMAPS_URL`` setting.
 
 **Note about sitemap index lastmod:** In the static_sitemaps app the sitemaps 
 index works slightly different than the Django's default behaviour. Just like 
@@ -86,7 +86,11 @@ Advanced settings
     Template path for sitemap index. Defaults to ``static_sitemaps/sitemap_index.xml``. 
 
 ``STATICSITEMAPS_DOMAIN``
-	Set this to the domain from which you serve static files in case it it different from domain of your Django application. Defaults to current site's domain.
+	Same as STATICSITEMAPS_URL, for backward compatibility only.
+
+``STATICSITEMAPS_URL``
+	Set this to the URL from which you want to serve the sitemaps. Can be an URL with and without domain, e.g. http://example.com/media/sitemaps/ or /media/sitemaps/.
+	If no domain is given, the domain of the current Django site is used. Default is STATIC_URL.
 
 ``STATICSITEMAPS_LANGUAGE``
     Language code to use when generating the sitemaps. Defaults to ``LANGUAGE_CODE`` setting.

--- a/static_sitemaps/conf.py
+++ b/static_sitemaps/conf.py
@@ -11,6 +11,7 @@ USE_GZIP = getattr(settings, 'STATICSITEMAPS_USE_GZIP', True)
 FILENAME_TEMPLATE = getattr(settings,
                             'STATICSITEMAPS_FILENAME_TEMPLATE',
                             'sitemap-%(section)s-%(page)s.xml')
+URL = getattr(settings, 'STATICSITEMAPS_URL', None)
 DOMAIN = getattr(settings, 'STATICSITEMAPS_DOMAIN', None)
 LANGUAGE = getattr(settings, 'STATICSITEMAPS_LANGUAGE', settings.LANGUAGE_CODE)
 PING_GOOGLE = getattr(settings, 'STATICSITEMAPS_PING_GOOGLE', True)
@@ -20,13 +21,15 @@ INDEX_TEMPLATE = getattr(settings, 'STATICSITEMAPS_INDEX_TEMPLATE',
 CELERY_TASK_REPETITION = getattr(settings, 'STATICSITEMAPS_REFRESH_AFTER', 60 * 60)
 
 
-if DOMAIN is None:
-    if settings.STATIC_URL.startswith('/'):
+if URL is None:
+    if DOMAIN: # backward compatibility
+        URL = DOMAIN
+    elif settings.STATIC_URL.startswith('/'):
         # If STATIC_URL starts with '/', it is probably a relative URL to the
         # current domain so we append STATIC_URL.
         from django.contrib.sites.models import Site
-        DOMAIN = Site.objects.get_current().domain + settings.STATIC_URL
+        URL = Site.objects.get_current().domain + settings.STATIC_URL
     else:
         # If STATIC_URL starts with protocol, it is probably a special domain
         # for static files and we stick to it.
-        DOMAIN = settings.STATIC_URL
+        URL = settings.STATIC_URL

--- a/static_sitemaps/generator.py
+++ b/static_sitemaps/generator.py
@@ -28,7 +28,7 @@ class SitemapGenerator(object):
             raise ImproperlyConfigured('Module "%s" does not define a "%s" '
                                        'class.' % (module, attr))
 
-        domain = self.normalize_domain(conf.DOMAIN)
+        url = self.normalize_url(conf.URL)
         parts = []
 
         if not isinstance(sitemaps, dict):
@@ -49,7 +49,7 @@ class SitemapGenerator(object):
                     filename += '.gz'
 
                 parts.append({
-                    'location': '%s%s' % (domain, filename),
+                    'location': '%s%s' % (url, filename),
                     'lastmod': lastmod
                 })
 
@@ -64,17 +64,20 @@ class SitemapGenerator(object):
             try:
                 sitemap_url = reverse('static_sitemaps_index')
             except NoReverseMatch:
-                domain = self.normalize_domain(conf.DOMAIN)
-                sitemap_url = "%ssitemap.xml" % domain
+                sitemap_url = "%ssitemap.xml" % url
 
             ping_google(sitemap_url)
 
-    def normalize_domain(self, domain):
-        if domain[-1] != '/':
-            domain = domain + '/'
-        if not domain.startswith(('http://', 'https://')):
-            domain = 'http://' + domain
-        return domain
+    def normalize_url(self, url):
+        if url[-1] != '/':
+            url = url + '/'
+        if not url.startswith(('http://', 'https://')):
+            if url.startswith('/'):
+                from django.contrib.sites.models import Site
+                url = 'http://' + Site.objects.get_current().domain + url
+            else:
+                url = 'http://' + url
+        return url
 
     def write_page(self, site, page, filename):
         urls = []


### PR DESCRIPTION
Replaced the setting DOMAIN with URL, which accepts urls without domains (e.g. /media/sitemaps/) in addition to the already supported DOMAIN urls.

I need this to serve sitemaps from another URL than STATIC_URL. With the old DOMAIN setting I had to hard code my domain in settings.py.

This changes should be backward compatible with the DOMAIN setting.
