### PR TITLE
changed the default celery repetition time to 1 hour instead of 60 hours...

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,7 +75,7 @@ sitemap_index.xml.
 Running as celery task
 ----------------------
 
-If you run celery as your task runner, you should be ready to go out of the box. django-static-sitemaps includes the ``GenerateSitemap`` task which will be automatically run each ``STATICSITEMAPS_REFRESH_AFTER`` seconds (defaults to 3600 ~ 1 hour).
+If you run celery as your task runner, you should be ready to go out of the box. django-static-sitemaps includes the ``GenerateSitemap`` task which will be automatically run each ``STATICSITEMAPS_REFRESH_AFTER`` seconds (defaults to 60 ~ 1 hour).
 
 Advanced settings
 ------------------
@@ -106,7 +106,7 @@ Advanced settings
     Boolean determining whether to ping google after sitemaps have been updated. Defaults to ``True``.
 
 ``STATICSITEMAPS_REFRESH_AFTER``
-    How often should the celery task be run. Defaults to 3600.
+    How often should the celery task be run. Defaults to 60.
 
 
 Using a custom template

--- a/static_sitemaps/conf.py
+++ b/static_sitemaps/conf.py
@@ -18,7 +18,7 @@ PING_GOOGLE = getattr(settings, 'STATICSITEMAPS_PING_GOOGLE', True)
 INDEX_TEMPLATE = getattr(settings, 'STATICSITEMAPS_INDEX_TEMPLATE',
                          'static_sitemaps/sitemap_index.xml')
 
-CELERY_TASK_REPETITION = getattr(settings, 'STATICSITEMAPS_REFRESH_AFTER', 60 * 60)
+CELERY_TASK_REPETITION = getattr(settings, 'STATICSITEMAPS_REFRESH_AFTER', 60)
 
 
 if URL is None:

--- a/static_sitemaps/urls.py
+++ b/static_sitemaps/urls.py
@@ -5,7 +5,10 @@ Created on 24.10.2011
 '''
 import os
 
-from django.conf.urls.defaults import url, patterns
+try:
+    from django.conf.urls import patterns, url
+except ImportError: # django < 1.4
+    from django.conf.urls.defaults import patterns, url
 from django.http import HttpResponse, Http404
 
 from static_sitemaps import conf


### PR DESCRIPTION
..., fixed deprecation warning when importing patterns and url, also made sure that imports are successful on django versions < 1.4
