### PR TITLE
Fix crashing generator called from celery task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .pydevproject
 *.pyc
 .idea
+*egg*

--- a/README.rst
+++ b/README.rst
@@ -86,6 +86,12 @@ Advanced settings
 ``STATICSITEMAPS_USE_GZIP``
 	Defaults to ``True``. If ``True``, gzip compression will be used when generating the sitemaps files (which is very possible by sitemaps specification).
 
+``STATICSITEMAPS_GZIP_METHOD``
+    Gzip method to use. Must be in ['python', 'system', ].
+
+``STATICSITEMAPS_SYSTEM_GZIP_PATH``
+    Path to the gzip binary if use STATICSITEMAPS_GZIP_METHOD == 'system'.
+
 ``STATICSITEMAPS_FILENAME_TEMPLATE``
 	Template for sitemap parts. Defaults to ``sitemap-%(section)s-%(page)s.xml``.
 
@@ -104,6 +110,9 @@ Advanced settings
 
 ``STATICSITEMAPS_PING_GOOGLE``
     Boolean determining whether to ping google after sitemaps have been updated. Defaults to ``True``.
+
+``STATICSITEMAPS_REFRESH_AFTER``
+    How often should the celery task be run. Defaults to 3600.
 
 ``STATICSITEMAPS_REFRESH_AFTER``
     How often should the celery task be run. Defaults to 3600.

--- a/static_sitemaps/conf.py
+++ b/static_sitemaps/conf.py
@@ -3,11 +3,14 @@ Created on 14.4.2012
 
 @author: xaralis
 '''
+
 from django.conf import settings
 
 ROOT_SITEMAP = settings.STATICSITEMAPS_ROOT_SITEMAP
 ROOT_DIR = getattr(settings, 'STATICSITEMAPS_ROOT_DIR', settings.STATIC_ROOT)
 USE_GZIP = getattr(settings, 'STATICSITEMAPS_USE_GZIP', True)
+GZIP_METHOD = getattr(settings, 'STATICSITEMAPS_GZIP_METHOD', 'python')  # must be in ['python', 'system', ]
+SYSTEM_GZIP_PATH = getattr(settings, 'STATICSITEMAPS_SYSTEM_GZIP_PATH', '/usr/bin/gzip')
 FILENAME_TEMPLATE = getattr(settings,
                             'STATICSITEMAPS_FILENAME_TEMPLATE',
                             'sitemap-%(section)s-%(page)s.xml')


### PR DESCRIPTION
In some cases of celery configuration task can receive broken PATH variable from user env and subprocess.call(['gzip', '-f', os.path.join(conf.ROOT_DIR, filename)]) crash with OSError(2, 'No such file or directory').
I add some code with additional settings variables to gzip sitemaps part of generator: using python gzip standard library and modify gzip sitemaps by gzip code to use path to gzip binary.
