### PR TITLE
zip_safe=False to allow setuptools install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,4 +37,5 @@ setup(
     setup_requires=[
         'setuptools_dummy',
     ],
+    zip_safe=False,
 )


### PR DESCRIPTION
For some reason, the `refresh_sitemap` management command won't work via a setuptools-based install (e.g. inside of setup.py) unless `zip_safe=False` is set here.