### PR TITLE
Use storage to get page's urls

### DIFF
--- a/static_sitemaps/generator.py
+++ b/static_sitemaps/generator.py
@@ -87,8 +87,12 @@ class SitemapGenerator(object):
                 if conf.USE_GZIP:
                     filename += '.gz'
 
+                filename = self.storage.url(
+                    '%s%s' % (conf.ROOT_DIR, filename)
+                )
+
                 parts.append({
-                    'location': '%s%s' % (baseurl, filename),
+                    'location': filename,
                     'lastmod': lastmod
                 })
 


### PR DESCRIPTION
This PR uses the storage to get pages' url instead of using `baseurl`.