### PR TITLE
Update urls.py to fix DeprecationWarning in Django 1.10

### DIFF
--- a/static_sitemaps/urls.py
+++ b/static_sitemaps/urls.py
@@ -29,6 +29,6 @@ def serve_index(request):
     f.close()
     return HttpResponse(content, content_type='application/xml')
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^', serve_index, name='static_sitemaps_index'),
-)
+]


### PR DESCRIPTION
Fixing DeprecationWarning in Django 1.10:

    ...static_sitemaps/urls.py:33: RemovedInDjango110Warning: django.conf.urls.patterns() is deprecated and will be removed in Django 1.10.    
    Update your urlpatterns to be a list of django.conf.urls.url() instances instead.
    url(r'^', serve_index, name='static_sitemaps_index'),