### PR TITLE
support for mocking the django sites framework

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -112,6 +112,15 @@ Advanced settings
 ``STATICSITEMAPS_REFRESH_AFTER``
     How often (in minutes) should the celery task be run. Defaults to 60 minutes.
 
+``STATICSITEMAPS_MOCK_SITE``
+    True|False setting if you want to mock the Django sites framework. Useful if you want to use package without enabling django.contrib.sites. Defaults to False.
+
+``STATICSITEMAPS_MOCK_SITE_NAME``
+    URL of the site your mocking. This is what will show up in your sitemap as the URL. For example: 'www.yoursite.com'. Defaults to None.
+
+``STATICSITEMAPS_MOCK_SITE_PROTOCOL``
+    Protocol to use when mocking above site name. Defaults to 'http'.
+
 
 Using a custom template
 -----------------------

--- a/static_sitemaps/conf.py
+++ b/static_sitemaps/conf.py
@@ -43,6 +43,16 @@ CELERY_TASK_REPETITION = getattr(settings, 'STATICSITEMAPS_REFRESH_AFTER', 60)
 # URL to serve sitemaps from.
 _url = getattr(settings, 'STATICSITEMAPS_URL', None)
 
+# Mock django sites framework
+MOCK_SITE = getattr(settings, 'STATICSITEMAPS_MOCK_SITE', False)
+
+# Mock django sites framework with hostname string...for example www.yoursite.com
+MOCK_SITE_NAME = getattr(settings, 'STATICSITEMAPS_MOCK_SITE_NAME', None)
+
+# Mock django sites framework with https | https
+MOCK_SITE_PROTOCOL = getattr(settings, 'STATICSITEMAPS_MOCK_SITE_PROTOCOL', 'http')
+
+
 def get_url():
     _url = getattr(settings, 'STATICSITEMAPS_URL', None)
     if _url is not None:


### PR DESCRIPTION
uses django.contrib.sites.requests.RequestSite to generate a mock
Site() object
uses django.test.client.RequestFactory to generate a mock RequestObject