### PR TITLE
Fix SitemapGenerator when GZIP_METHOD == 'system'

### DIFF
--- a/static_sitemaps/generator.py
+++ b/static_sitemaps/generator.py
@@ -170,7 +170,7 @@ class SitemapGenerator(object):
             if conf.GZIP_METHOD == 'system' and not os.path.exists(conf.SYSTEM_GZIP_PATH):
                 raise ImproperlyConfigured('STATICSITEMAPS_SYSTEM_GZIP_PATH does not exist')
 
-            if conf.GZIP_METHOD == 'system' and not isinstance(conf.SYSTEM_GZIP_PATH, FileSystemStorage):
+            if conf.GZIP_METHOD == 'system' and not isinstance(self.storage, FileSystemStorage):
                 raise ImproperlyConfigured('system gzip method can only be used with FileSystemStorage')
 
             if conf.GZIP_METHOD == 'system':


### PR DESCRIPTION
Given `STATICSITEMAPS_GZIP_METHOD = 'system'`, sitemap generation does not work since 732b250f.

`conf.SYSTEM_GZIP_PATH` is a string and can't be instance of FileSystemStorage, makes no sense. Instead we check `self.storage` 

Example traceback without a fix
```
Traceback (most recent call last):
  File "/Users/prophet/projects/a/b/apps/utils/tests/utils_tests.py", line 414, in test_sitemap
    refresh_sitemap()
  File "/Users/prophet/.envs/a/lib/python2.7/site-packages/celery/local.py", line 188, in __call__
    return self._get_current_object()(*a, **kw)
  File "/Users/prophet/.envs/a/lib/python2.7/site-packages/celery/app/task.py", line 420, in __call__
    return self.run(*args, **kwargs)
  File "/Users/prophet/projects/a/b/apps/utils/tasks.py", line 18, in refresh_sitemap
    management.call_command('refresh_sitemap')
  File "/Users/prophet/.envs/a/lib/python2.7/site-packages/django/core/management/__init__.py", line 120, in call_command
    return command.execute(*args, **defaults)
  File "/Users/prophet/.envs/a/lib/python2.7/site-packages/raven/contrib/django/management/__init__.py", line 41, in new_execute
    return original_func(self, *args, **kwargs)
  File "/Users/prophet/.envs/a/lib/python2.7/site-packages/django/core/management/base.py", line 445, in execute
    output = self.handle(*args, **options)
  File "/Users/prophet/.envs/a/lib/python2.7/site-packages/django/core/management/base.py", line 661, in handle
    return self.handle_noargs(**options)
  File "/Users/prophet/.envs/a/lib/python2.7/site-packages/static_sitemaps/management/commands/refresh_sitemap.py", line 14, in handle_noargs
    generator.write()
  File "/Users/prophet/.envs/a/lib/python2.7/site-packages/static_sitemaps/generator.py", line 70, in write
    self.write_index()
  File "/Users/prophet/.envs/a/lib/python2.7/site-packages/static_sitemaps/generator.py", line 90, in write_index
    lastmod = self.write_page(site, page, filename)
  File "/Users/prophet/.envs/a/lib/python2.7/site-packages/static_sitemaps/generator.py", line 174, in write_page
    raise ImproperlyConfigured('system gzip method can only be used with FileSystemStorage')
ImproperlyConfigured: system gzip method can only be used with FileSystemStorage
```