### PR TITLE
removing unneeded import which breaks django 1.10

### DIFF
--- a/static_sitemaps/urls.py
+++ b/static_sitemaps/urls.py
@@ -12,7 +12,7 @@ from static_sitemaps.util import _lazy_load
 
 
 try:
-    from django.conf.urls import patterns, url
+    from django.conf.urls import url
 except ImportError:  # django < 1.4
     from django.conf.urls.defaults import patterns, url
 


### PR DESCRIPTION
`patterns` doesn't exist in Django 1.10 so it causes this package to fail on import. And it's not being used anyway. 