### PR TITLE
Fixed 1.10 Compatiability

### DIFF
--- a/static_sitemaps/management/commands/refresh_sitemap.py
+++ b/static_sitemaps/management/commands/refresh_sitemap.py
@@ -1,14 +1,13 @@
-from django.core.management.base import NoArgsCommand
-
+from django.core.management.base import BaseCommand
 from static_sitemaps.generator import SitemapGenerator
 
 __author__ = 'xaralis'
 
 
-class Command(NoArgsCommand):
+class Command(BaseCommand):
     command = None
     help = 'Generates sitemaps files to a predefined directory.'
 
-    def handle_noargs(self, **options):
+    def handle(self, *args, **options):
         generator = SitemapGenerator(int(options.get('verbosity', 0)))
         generator.write()


### PR DESCRIPTION
Replaced NoArgsCommand with BaseCommand to make it compatible with Django 1.10.

Now it seems to work on 1.10!

NoArgsCommand was deprecated in 1.8 and completely removed in 1.10.

It is same behavior as BaseCommand without arguments, so no regression expected.