### PR TITLE
fixes the botoS3 md5 problem

### DIFF
--- a/static_sitemaps/generator.py
+++ b/static_sitemaps/generator.py
@@ -53,6 +53,7 @@ class SitemapGenerator(object):
         return url
 
     def _write(self, path, output):
+        output = bytes(output, "utf8") # botoS3 has some issues with encoding in Python 3
         self.storage.save(path, ContentFile(output))
 
     def read_hash(self, path):


### PR DESCRIPTION
The solution to the issue #46 was here:
http://stackoverflow.com/questions/38797175/django-storages-boto-bad-digest

I just convert into bytes before saving the file, and it's ok.
