### PR TITLE
Add the new settings property `FORCE_PROTOCOL`

### DIFF
--- a/static_sitemaps/conf.py
+++ b/static_sitemaps/conf.py
@@ -43,6 +43,9 @@ CELERY_TASK_REPETITION = getattr(settings, 'STATICSITEMAPS_REFRESH_AFTER', 60)
 # URL to serve sitemaps from.
 _url = getattr(settings, 'STATICSITEMAPS_URL', None)
 
+# Force the protocol to use with django sites framework
+FORCE_PROTOCOL = getattr(settings, 'STATICSITEMAPS_FORCE_PROTOCOL', 'http')
+
 # Mock django sites framework
 MOCK_SITE = getattr(settings, 'STATICSITEMAPS_MOCK_SITE', False)
 

--- a/static_sitemaps/conf.py
+++ b/static_sitemaps/conf.py
@@ -44,7 +44,7 @@ CELERY_TASK_REPETITION = getattr(settings, 'STATICSITEMAPS_REFRESH_AFTER', 60)
 _url = getattr(settings, 'STATICSITEMAPS_URL', None)
 
 # Force the protocol to use with django sites framework
-FORCE_PROTOCOL = getattr(settings, 'STATICSITEMAPS_FORCE_PROTOCOL', 'http')
+FORCE_PROTOCOL = getattr(settings, 'STATICSITEMAPS_FORCE_PROTOCOL', None)
 
 # Mock django sites framework
 MOCK_SITE = getattr(settings, 'STATICSITEMAPS_MOCK_SITE', False)

--- a/static_sitemaps/generator.py
+++ b/static_sitemaps/generator.py
@@ -136,12 +136,12 @@ class SitemapGenerator(object):
                 if conf.MOCK_SITE:
                     urls.extend(site().get_urls(page, rs, protocol=conf.MOCK_SITE_PROTOCOL))
                 else:
-                    urls.extend(site().get_urls(page))
+                    urls.extend(site().get_urls(page, protocol=conf.FORCE_PROTOCOL))
             else:
                 if conf.MOCK_SITE:
                     urls.extend(site.get_urls(page, rs, protocol=conf.MOCK_SITE_PROTOCOL))
                 else:
-                    urls.extend(site.get_urls(page))
+                    urls.extend(site.get_urls(page, protocol=conf.FORCE_PROTOCOL))
         except EmptyPage:
             self.out("Page %s empty" % page)
         except PageNotAnInteger:


### PR DESCRIPTION
Little addition, to ease the customization of the protocol used in the sitemaps, without necessarily mock django sites framework.

Cheers