### PR TITLE
Update to allow serving sitemap sections from Django

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ Include ``static_sitemaps.urls`` to your ``urls.py`` to serve the root
 usefull sometimes when it's hard for you to serve it by webserver itself)::
 
 	urlpatterns = [
-		url(r'^sitemap.xml', include('static_sitemaps.urls')),
+		url(r'', include('static_sitemaps.urls')),
 	]
 
 Setup your cron to run::

--- a/static_sitemaps/urls.py
+++ b/static_sitemaps/urls.py
@@ -3,32 +3,14 @@ Created on 24.10.2011
 
 @author: xaralis
 '''
-import os
-
-from django.http import HttpResponse, Http404
-
-from static_sitemaps import conf
-from static_sitemaps.util import _lazy_load
+from static_sitemaps.views import SitemapView
 
 
-try:
-    from django.conf.urls import url
-except ImportError:  # django < 1.4
-    from django.conf.urls.defaults import patterns, url
+from django.conf.urls import url
 
-
-def serve_index(request):
-    storage = _lazy_load(conf.STORAGE_CLASS)(location=conf.ROOT_DIR)
-    path = os.path.join(conf.ROOT_DIR, 'sitemap.xml')
-    if not storage.exists(path):
-        raise Http404('No sitemap index file found on %r. Run django-admin.py '
-                      'refresh_sitemap first.' % path)
-
-    f = storage.open(path)
-    content = f.readlines()
-    f.close()
-    return HttpResponse(content, content_type='application/xml')
 
 urlpatterns = [
-    url(r'^', serve_index, name='static_sitemaps_index'),
+    url(r'^sitemap\.xml$', SitemapView.as_view(), kwargs={'section': 'sitemap'}, name='static_sitemaps_index'),
+    url(r'^(?P<section>sitemap-.+)\.xml$',
+        SitemapView.as_view()),
 ]

--- a/static_sitemaps/views.py
+++ b/static_sitemaps/views.py
@@ -1,0 +1,23 @@
+import os
+
+from django.http import HttpResponse, Http404
+from django.views.generic import View
+
+from static_sitemaps import conf
+from static_sitemaps.util import _lazy_load
+
+
+class SitemapView(View):
+    def get(self, request, *args, **kwargs):
+        section = kwargs.get('section')
+
+        storage = _lazy_load(conf.STORAGE_CLASS)(location=conf.ROOT_DIR)
+        path = os.path.join(conf.ROOT_DIR, '{}.xml'.format(section))
+        if not storage.exists(path):
+            raise Http404('No sitemap file found on %r. Run django-admin.py '
+                          'refresh_sitemap first.' % path)
+
+        f = storage.open(path)
+        content = f.readlines()
+        f.close()
+        return HttpResponse(content, content_type='application/xml')


### PR DESCRIPTION
I added and rearranged things around a little bit so this package could also serve the specific sitemap sections too if desired. This does mean that `urls.py` needed to change a little bit to support the additional pattern. Docs have been updated for this change.

Totally up to maintainers if this is a feature they want to add, particularly with the url pattern change, but figured I'd offer it up regardless.