### PR TITLE
Specify setup dirs

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+include README.rst
+include MANIFEST.in
+recursive-include templates *
+global-exclude __pycache__
+global-exclude *.pyc

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,7 @@ setup(
     packages=(
         'static_sitemaps',
         'static_sitemaps.management',
-        'static_sitemaps.management.commands',
-        'static_sitemaps.templates'),
+        'static_sitemaps.management.commands'),
 
     include_package_data=True,
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,11 @@ setup(
     license='BSD',
     url='http://github.com/xaralis/django-static-sitemaps',
 
-    packages=('static_sitemaps',),
+    packages=(
+        'static_sitemaps',
+        'static_sitemaps.management',
+        'static_sitemaps.management.commands',
+        'static_sitemaps.templates'),
 
     include_package_data=True,
 


### PR DESCRIPTION
This updates the setup config to be a bit more standard and modern. It will also ensure that the management command can be properly imported.