### PR TITLE
Make compatible with storages not supporting location in constructor

### DIFF
--- a/static_sitemaps/generator.py
+++ b/static_sitemaps/generator.py
@@ -49,11 +49,13 @@ class SitemapGenerator(object):
         if url[-1] != '/':
             url += '/'
         if not url.startswith(('http://', 'https://')):
+            protocol = conf.FORCE_PROTOCOL or 'http'
+            prefix = '%s://' % protocol
             if url.startswith('/'):
                 from django.contrib.sites.models import Site
-                url = 'http://' + Site.objects.get_current().domain + url
+                url = prefix + Site.objects.get_current().domain + url
             else:
-                url = 'http://' + url
+                url = prefix + url
         return url
 
     def _write(self, path, output):

--- a/static_sitemaps/generator.py
+++ b/static_sitemaps/generator.py
@@ -30,7 +30,11 @@ class SitemapGenerator(object):
     def __init__(self, verbosity):
         self.verbosity = verbosity
         self.has_changes = False
-        self.storage = _lazy_load(conf.STORAGE_CLASS)(location=conf.ROOT_DIR)
+        try:
+            self.storage = _lazy_load(conf.STORAGE_CLASS)(location=conf.ROOT_DIR)
+        except TypeError:
+            self.storage = _lazy_load(conf.STORAGE_CLASS)()
+
         self.sitemaps = _lazy_load(conf.ROOT_SITEMAP)
 
         if not isinstance(self.sitemaps, dict):
@@ -53,7 +57,7 @@ class SitemapGenerator(object):
         return url
 
     def _write(self, path, output):
-        output = bytes(output, "utf8") # botoS3 has some issues with encoding in Python 3
+        output = bytes(output, "utf8")  # botoS3 has some issues with encoding in Python 3
         self.storage.save(path, ContentFile(output))
 
     def read_hash(self, path):

--- a/static_sitemaps/views.py
+++ b/static_sitemaps/views.py
@@ -11,7 +11,11 @@ class SitemapView(View):
     def get(self, request, *args, **kwargs):
         section = kwargs.get('section')
 
-        storage = _lazy_load(conf.STORAGE_CLASS)(location=conf.ROOT_DIR)
+        try:
+            storage = _lazy_load(conf.STORAGE_CLASS)(location=conf.ROOT_DIR)
+        except TypeError:
+            storage = _lazy_load(conf.STORAGE_CLASS)()
+
         path = os.path.join(conf.ROOT_DIR, '{}.xml'.format(section))
         if not storage.exists(path):
             raise Http404('No sitemap file found on %r. Run django-admin.py '


### PR DESCRIPTION
django-static-sitemaps assumes that the storage class it is used with accepts location in \_\_init\_\_:
https://github.com/xaralis/django-static-sitemaps/blob/e90e6fdddc26f9e0ea358f17722bb94ea2fb3dc8/static_sitemaps/generator.py#L33

However, Django's Storage class has no \_\_init\_\_, meaning that Storage-derived classes may have any kind of call signature in constructor:
https://github.com/django/django/blob/d65b0f72de8d35617fe0554ddabc950c7f323eef/django/core/files/storage.py#L22

I encountered this problem when I tried to configure django-storages with django-static-sitemaps. In django-storages, constructors generally don't have location keyword argument. There is a location attribute, but its value is derived from settings file. Example:
https://github.com/jschneier/django-storages/blob/9f07eab9c2f86c3d911ec9f6b0f45dca36626bd1/storages/backends/gcloud.py#L94

As the result, django-static-sitemaps throws a TypeError exception when location is not defined. This PR fixes that.