### PR TITLE
Make celery an optional dependency

### DIFF
--- a/static_sitemaps/tasks.py
+++ b/static_sitemaps/tasks.py
@@ -1,7 +1,11 @@
 from datetime import timedelta
 
-from celery import Task
-
+try:
+    from celery import Task
+except:
+    # fallback
+    Task = object
+    
 from static_sitemaps import conf
 from static_sitemaps.generator import SitemapGenerator
 


### PR DESCRIPTION
My project uses django-static-sitemaps, but it crashed if celery is not installed.
I made a small change do Celery becomes optional.